### PR TITLE
fix: handle connection pool creation failure and return handles to pool

### DIFF
--- a/db/commonpool/pool.go
+++ b/db/commonpool/pool.go
@@ -82,6 +82,9 @@ func NewConnectorPool(user, password string) (*ConnectorPool, error) {
 	p, err := connectpool.NewConnectPool(poolConfig)
 
 	if err != nil {
+		// failed to create connection pool, maybe the user is not exist or password is wrong
+		// put the handles back to pool
+		cp.putHandle()
 		return nil, err
 	}
 	cp.pool = p


### PR DESCRIPTION
# Description

fix: handle connection pool creation failure and return handles to pool

Jira: https://jira.taosdata.com:18080/browse/TS-6774

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
