### PR TITLE
fix: enhance IP parsing to handle IPv6 addresses and zone information

### DIFF
--- a/tools/iptool/ip.go
+++ b/tools/iptool/ip.go
@@ -12,5 +12,14 @@ func GetRealIP(r *http.Request) net.IP {
 		return net.ParseIP(ip)
 	}
 	host, _, _ := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr))
-	return net.ParseIP(host)
+	parsedIP := net.ParseIP(host)
+	if parsedIP != nil {
+		return parsedIP
+	}
+	// Fallback to resolving the host if the host has zone information
+	ipAddr, err := net.ResolveIPAddr("ip", host)
+	if err != nil {
+		return nil
+	}
+	return ipAddr.IP
 }

--- a/tools/iptool/ip_test.go
+++ b/tools/iptool/ip_test.go
@@ -33,3 +33,21 @@ func TestGetRealIPWithNoIP(t *testing.T) {
 	host, _, _ := net.SplitHostPort(req.RemoteAddr)
 	assert.Equal(t, host, ip.String())
 }
+
+func TestParseIpv6(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://example.com", nil)
+
+	req.RemoteAddr = "[fe80::4720:bdc2:e3a7:b2bc]:6041"
+	ip := GetRealIP(req)
+	assert.Equal(t, "fe80::4720:bdc2:e3a7:b2bc", ip.String())
+
+	// zone with %15 is used to specify the network interface in IPv6
+	req.RemoteAddr = "[fe80::4720:bdc2:e3a7:b2bd%15]:6041"
+	ip = GetRealIP(req)
+	assert.Equal(t, "fe80::4720:bdc2:e3a7:b2bd", ip.String())
+
+	// wrong ipv6 format
+	req.RemoteAddr = "[fe80::4720:bdc2:e3a7:gggg]:6041"
+	ip = GetRealIP(req)
+	assert.Nil(t, ip)
+}


### PR DESCRIPTION
# Description

fix whitelist check ipv6 with zone infomation

Jira: https://jira.taosdata.com:18080/browse/TD-36109

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
