### PR TITLE
enh: update log rotation count from 30 to 3 in configuration

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -56,10 +56,10 @@ func TestInit(t *testing.T) {
 				Log: &Log{
 					Level:                 "info",
 					Path:                  logPath,
-					RotationCount:         30,
+					RotationCount:         3,
 					RotationTime:          time.Hour * 24,
 					RotationSize:          1 * 1024 * 1024 * 1024, // 1G
-					KeepDays:              30,
+					KeepDays:              3,
 					Compress:              false,
 					ReservedDiskSize:      1 * 1024 * 1024 * 1024,
 					EnableSqlToCsvLogging: false,

--- a/config/log.go
+++ b/config/log.go
@@ -43,9 +43,9 @@ func initLog() {
 	_ = viper.BindEnv("log.level", "TAOS_ADAPTER_LOG_LEVEL")
 	pflag.String("log.level", "info", `log level (trace debug info warning error). Env "TAOS_ADAPTER_LOG_LEVEL"`)
 
-	viper.SetDefault("log.rotationCount", 30)
+	viper.SetDefault("log.rotationCount", 3)
 	_ = viper.BindEnv("log.rotationCount", "TAOS_ADAPTER_LOG_ROTATION_COUNT")
-	pflag.Uint("log.rotationCount", 30, `log rotation count. Env "TAOS_ADAPTER_LOG_ROTATION_COUNT"`)
+	pflag.Uint("log.rotationCount", 3, `log rotation count. Env "TAOS_ADAPTER_LOG_ROTATION_COUNT"`)
 
 	viper.SetDefault("log.rotationTime", time.Hour*24)
 	_ = viper.BindEnv("log.rotationTime", "TAOS_ADAPTER_LOG_ROTATION_TIME")
@@ -55,9 +55,9 @@ func initLog() {
 	_ = viper.BindEnv("log.rotationSize", "TAOS_ADAPTER_LOG_ROTATION_SIZE")
 	pflag.String("log.rotationSize", "1GB", `log rotation size(KB MB GB), must be a positive integer. Env "TAOS_ADAPTER_LOG_ROTATION_SIZE"`)
 
-	viper.SetDefault("log.keepDays", 30)
+	viper.SetDefault("log.keepDays", 3)
 	_ = viper.BindEnv("log.keepDays", "TAOS_ADAPTER_LOG_KEEP_DAYS")
-	pflag.Uint("log.keepDays", 30, `log retention days, must be a positive integer. Env "TAOS_ADAPTER_LOG_KEEP_DAYS"`)
+	pflag.Uint("log.keepDays", 3, `log retention days, must be a positive integer. Env "TAOS_ADAPTER_LOG_KEEP_DAYS"`)
 
 	viper.SetDefault("log.compress", false)
 	_ = viper.BindEnv("log.compress", "TAOS_ADAPTER_LOG_COMPRESS")

--- a/example/config/taosadapter.toml
+++ b/example/config/taosadapter.toml
@@ -83,10 +83,10 @@ keyFile = ""
 level = "info"
 
 # Number of log file rotations before deletion.
-rotationCount = 30
+rotationCount = 3
 
 # The number of days to retain log files.
-keepDays = 30
+keepDays = 3
 
 # The maximum size of a log file before rotation.
 rotationSize = "1GB"

--- a/monitor/recordsql/record_test.go
+++ b/monitor/recordsql/record_test.go
@@ -327,10 +327,13 @@ func TestRotate(t *testing.T) {
 	}()
 	config.Conf.Log.Path = tmpDir
 	oldRotateSize := config.Conf.Log.RotationSize
+	oldRotationCount := config.Conf.Log.RotationCount
 	defer func() {
 		config.Conf.Log.RotationSize = oldRotateSize
+		config.Conf.Log.RotationCount = oldRotationCount
 	}()
 	config.Conf.Log.RotationSize = 20
+	config.Conf.Log.RotationCount = 10
 	err := StartRecordSql(time.Now().Format(InputTimeFormat), time.Now().Add(time.Second*2).Format(InputTimeFormat), "")
 	require.NoError(t, err)
 	defer func() {


### PR DESCRIPTION
# Description

enh: update log rotation count from 30 to 3 in configuration

# Issue(s)

- resolve: https://project.feishu.cn/taosdata_td/feature/detail/6837004097

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
